### PR TITLE
Restoring compare this data

### DIFF
--- a/src/autosuggest/autosuggest-source.js
+++ b/src/autosuggest/autosuggest-source.js
@@ -12,14 +12,15 @@ class AutosuggestSource {
         if (this.config.options)
             return Promise.resolve(this.config.options);
 
-        return odn.suggest(this.config.suggestType, term, GlobalConstants.AUTOCOMPLETE_SHOWN_OPTIONS);
+        const limit = GlobalConstants.AUTOCOMPLETE_SHOWN_OPTIONS;
+        return odn.suggest(this.config.suggestType, term, limit, this.config.params);
     }
 
     display(container, options) {
         if (options.length === 0) return [];
 
-        if (this.sort) options = _.sortBy(options, this.sort).slice(0, GlobalConstants.AUTOCOMPLETE_SHOWN_OPTIONS);
-        if (this.filter) options = options.filter(this.filter);
+        if (this.config.sort) options = _.sortBy(options, this.config.sort).slice(0, GlobalConstants.AUTOCOMPLETE_SHOWN_OPTIONS);
+        if (this.config.filter) options = options.filter(this.config.filter);
 
         const category = container
             .append('li')

--- a/src/autosuggest/autosuggest.js
+++ b/src/autosuggest/autosuggest.js
@@ -1,8 +1,9 @@
 'use strict';
 
 class Autosuggest {
-    constructor(resultSelector) {
-        this.sources = AUTOSUGGEST_SOURCES.map(config => new AutosuggestSource(config));
+    constructor(resultSelector, sources) {
+        sources = sources || AUTOSUGGEST_SOURCES;
+        this.sources = sources.map(config => new AutosuggestSource(config));
         this.results = new AutosuggestResults(resultSelector);
         this.currentTerm = '';
         this.time = Date.now();
@@ -21,8 +22,6 @@ class Autosuggest {
                 } else {
                     self.results.keydown(keyCode);
                 }
-
-                Cookies.remove('refinePopupCollapsed');
             })
             .on('input', function() {
                 self.throttledSuggest(this.value);

--- a/src/entity.js
+++ b/src/entity.js
@@ -1,7 +1,11 @@
 
 $(document).ready(function() {
+    const navigate = new EntityNavigate(_data.entities, _data.variable.id, _data.constraints);
+    window.entityNavigate = navigate;
+
     menuMouseHandlers();
     autosuggest();
+    compareAutosuggest(navigate);
     drawMap();
     drawCharts();
     apiBadges();
@@ -10,19 +14,31 @@ $(document).ready(function() {
     attachMobileMenuHandlers();
     expandMobileQuestions();
     citationTooltip();
-
-    window.entityNavigate =
-        new EntityNavigate(_data.entities, _data.variable.id, _data.constraints);
 });
 
+// Main search bar autosuggest.
 function autosuggest() {
-    // Main search bar autosuggest
     new Autosuggest('.region-list')
         .listen('.search-bar-input');
 
-    // Mobile autosuggest
     new Autosuggest('.add-region-results-mobile')
         .listen('.add-region-input-mobile');
+}
+
+// Compare this data autosuggest that shows only entities
+// with data for the current variable.
+function compareAutosuggest(navigate) {
+    const entitySource = _.find(AUTOSUGGEST_SOURCES, {suggestType: 'entity'});
+    const entityIDSet = new Set(_data.entities.map(_.property('id')));
+    const source = _.extend({}, entitySource, {
+        select: entity => navigate.add(entity).url(),
+        params: {variable_id: _data.variable.id},
+        filter: entity => !entityIDSet.has(entity.id)
+    });
+
+    new Autosuggest('.add-region-results', [source])
+        .listen('.add-region-input');
+
 }
 
 function drawMap() {

--- a/src/navigate/entity.js
+++ b/src/navigate/entity.js
@@ -35,6 +35,10 @@ class EntityNavigate {
         return new EntityNavigate(entities, this.variableID, this.query);
     }
 
+    clearVariable() {
+        return new EntityNavigate(this.entities);
+    }
+
     topic(topicID) {
         return this.variable(topicID);
     }

--- a/src/odn-client/odn-client.js
+++ b/src/odn-client/odn-client.js
@@ -52,13 +52,17 @@ class ODNClient {
      *
      * Relation must be one of parent, child, sibling, or peer.
      */
-    related(entityID, relation, limit) {
+    related(entityID, relation, limit, variableID) {
         return getJSON(this.relatedURL.apply(this, arguments))
             .then(response => Promise.resolve({[relation]: response.relatives}));
     }
 
-    relatedURL(entityID, relation, limit) {
-        return this.url(`entity/v1/${relation}`, {entity_id: entityID, limit});
+    relatedURL(entityID, relation, limit, variableID) {
+        return this.url(`entity/v1/${relation}`, {
+            limit,
+            entity_id: entityID,
+            variable_id: variableID
+        });
     }
 
     /**

--- a/src/odn-client/odn-client.js
+++ b/src/odn-client/odn-client.js
@@ -166,7 +166,7 @@ class ODNClient {
         }, forEntities(entityIDs), constraints));
     }
 
-    suggest(type, query, limit) {
+    suggest(type, query, limit, params) {
         if (query === '') return Promise.resolve([]);
 
         return getJSON(this.suggestURL.apply(this, arguments)).then(response => {
@@ -174,13 +174,14 @@ class ODNClient {
         });
     }
 
-    suggestURL(type, query, limit) {
+    suggestURL(type, query, limit, params) {
         limit = limit || 10;
+        params = params || {};
 
-        return this.url(`suggest/v1/${type}`, {
+        return this.url(`suggest/v1/${type}`, _.extend({
             query,
             limit
-        });
+        }, params));
     }
 
     url(relativePath, clientParams) {

--- a/views/_region-navigation.ejs
+++ b/views/_region-navigation.ejs
@@ -14,16 +14,22 @@
         </div>
         <% include questions/_questions %>
 
-        <% if (related.peer.length > 0 && topic.id !== 'finance') { %>
-            <div id="peers">
-                <h2>Compare this Data</h2>
-                <ul id="similar-regions">
-                <% related.peer[0].entities.forEach(region => { %>
-                    <li><a class="region-link" href=<%= navigate.add(region).url() %><%- (entities.length >= 2) ? ' rel="nofollow"' : '' %>><%= region.name %> <em class="fa fa-plus"></em></a></li>
-                <% }); %>
-                </ul>
+        <div id="peers">
+            <h2>Compare this Data</h2>
+
+            <div class="add-region">
+                <i class="fa fa-plus"></i><input class="add-region-input" type="text" placeholder="Add Location">
+                <ul class="add-region-results" style="display: none;"></ul>
             </div>
-        <% } %>
+
+            <% if (related.peer.length > 0 && topic.id !== 'finance') { %>
+                <ul id="similar-regions">
+                    <% related.peer[0].entities.forEach(region => { %>
+                        <li><a class="region-link" href=<%= navigate.add(region).url() %><%- (entities.length >= 2) ? ' rel="nofollow"' : '' %>><%= region.name %> <em class="fa fa-plus"></em></a></li>
+                    <% }); %>
+                </ul>
+            <% } %>
+        </div>
 
         <% if (related.sibling.length > 0) { %>
             <div id="siblings">

--- a/views/_region-navigation.ejs
+++ b/views/_region-navigation.ejs
@@ -22,7 +22,7 @@
                 <ul class="add-region-results" style="display: none;"></ul>
             </div>
 
-            <% if (related.peer.length > 0 && topic.id !== 'finance') { %>
+            <% if (related.peer.length > 0) { %>
                 <ul id="similar-regions">
                     <% related.peer[0].entities.forEach(region => { %>
                         <li><a class="region-link" href=<%= navigate.add(region).url() %><%- (entities.length >= 2) ? ' rel="nofollow"' : '' %>><%= region.name %> <em class="fa fa-plus"></em></a></li>
@@ -36,7 +36,7 @@
                 <h2 class="places-in-region-header">
                     Others in
                     <% const parentRegion = related.parent[0].entities[0]; %>
-                    <a class="parent-link" href="<%= navigate.to(parentRegion).url() %>"><%= parentRegion.name %></a>
+                    <a class="parent-link" href="<%= navigate.to(parentRegion).clearVariable().url() %>"><%= parentRegion.name %></a>
                 </h2>
 
                 <ul class="places-in-region-list">
@@ -57,7 +57,7 @@
 
                         <ul class="places-in-region-list">
                             <% relative.entities.forEach(child => { %>
-                                <li><a class="region-link" href="<%= navigate.to(child).url() %>"><%= child.name %></a></li>
+                                <li><a class="region-link" href="<%= navigate.to(child).clearVariable().url() %>"><%= child.name %></a></li>
                             <% }); %>
                         </ul>
                     </div>


### PR DESCRIPTION
Small follow-up release after `v.data.8`.

Changelog:
 - Restores "compare this data" search box.
 - Entities without data for the current variable now excluded from siblings and peers.
 - Links to parents and children now go to main entity landing page instead of linking to the current variable.