### PR TITLE
EN-34024: remove home "questions" links

### DIFF
--- a/tests/home-mobile.js
+++ b/tests/home-mobile.js
@@ -12,7 +12,6 @@ casper.test.begin('homepage mobile', function(test) {
         test.assertTitle(title);
         test.assertSelectorHasText('.logo', title);
 
-        testQuestionsList(test);
         testCategoryList(test);
 
         testMainSuggest(test);
@@ -20,10 +19,6 @@ casper.test.begin('homepage mobile', function(test) {
         test.done();
     });
 });
-
-function testQuestionsList(test) {
-    assertToggles(test, '.questions-dropdown', '.questions-list-container');
-}
 
 function testCategoryList(test) {
     assertToggles(test, '.categories-dropdown-mobile', '.categories-list-mobile');
@@ -37,4 +32,3 @@ function testCategoryList(test) {
 function categoryURL(category) {
     return '/search?categories=' + category;
 }
-

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -3,7 +3,6 @@
 <% include _home-hero %>
 <section class="home-page">
   <div role="main">
-    <% include _home-questions %>
     <% include _home-categories %>
     <% include _home-regions %>
     <% include _home-partners %>


### PR DESCRIPTION
We noticed during an ODN outage that the links in the "Questions"
section were returning 500 errors for every link. We removed them for
now so that customers don't think the site is totally broken.