### PR TITLE
EN-34916: ODN question links redirect incorrectly

### DIFF
--- a/app/controllers/redirect/region.js
+++ b/app/controllers/redirect/region.js
@@ -43,7 +43,7 @@ module.exports = (request, response) => {
         const entityIDs = (request.params.regionIDs || '').split('-');
         const entityNames = (request.params.regionNames || '').split('-');
         const entities = _.zip(entityIDs, entityNames)
-            .map(pair => _.fromPairs(['id', 'name'], pair))
+            .map(pair => _.zipObject(['id', 'name'], pair))
             .filter(entity => !_.isEmpty(entity.id));
 
         const url = new EntityNavigate(entities, variableID, constraints).url();


### PR DESCRIPTION
Fixed a bug from when I converted the code from lodash 3.10.1 to 4.17.15.

Before change:
On a questions URL request, the entities variable in the code in question was being set to an empty array resulting in a 404.

After change:
Entities is properly created to look something like:

> [{
>     "id":"310M200US41180",
>     "name":"St_Louis_Metro_Area_MO_IL"
> }]

