### PR TITLE
add logging for IP and Agent

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,6 +30,7 @@ const BLOCKAGENTS = (process.env.BLOCKAGENTS || "").split(",");
 app.use((req, res, next) => {
   var ip = req.headers["x-forwarded-for"];
   var agent = req.headers["user-agent"];
+  console.log("IP:", ip, "AGENT:", agent);
   if(BLOCKLIST.includes(ip) || BLOCKAGENTS.includes(agent)) {
     console.log("Blocked", ip, req.headers["user-agent"]);
     res.end("Oh no you din't!");


### PR DESCRIPTION
Before:
- No IP/Agent logging

After:
- Log IP and Agent of request
- Why? Because we are getting spammed.